### PR TITLE
[Claude Code] Fix horizontal scrolling in static embedding modal

### DIFF
--- a/frontend/src/metabase/components/CodeBlock/CodeBlock.module.css
+++ b/frontend/src/metabase/components/CodeBlock/CodeBlock.module.css
@@ -4,6 +4,14 @@
       background-color: var(--mb-color-brand-light);
       color: var(--mb-color-brand);
     }
+    
+    .cm-editor {
+      max-width: 100%;
+    }
+    
+    .cm-scroller {
+      overflow-x: auto !important;
+    }
   }
 }
 

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/CodeSample.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/CodeSample.tsx
@@ -43,10 +43,10 @@ export const CodeSample = ({
   );
 
   return (
-    <div className={className} data-testid={dataTestId}>
+    <div className={cx(className, CS.wFull)} data-testid={dataTestId}>
       {(title || languageOptions.length > 1) && (
-        <div className={cx(CS.flex, CS.alignCenter)}>
-          {title && <h4>{title}</h4>}
+        <div className={cx(CS.flex, CS.alignCenter, CS.wFull)}>
+          {title && <h4 className={CS.flexShrink1}>{title}</h4>}
           {languageOptions.length > 1 ? (
             <Select
               className={CS.mlAuto}
@@ -75,6 +75,7 @@ export const CodeSample = ({
           CS.relative,
           CS.mt2,
           CS.overflowHidden,
+          CS.wFull,
         )}
       >
         <CodeBlock

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/PreviewPane/PreviewPane.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/PreviewPane/PreviewPane.styled.tsx
@@ -13,6 +13,7 @@ export const PreviewPaneContainer = styled.div<{
 }>`
   width: 100%;
   min-height: 17.5rem;
+  max-width: 100%; /* Ensure it doesn't exceed its container */
 
   ${({ hidden }) =>
     hidden &&
@@ -38,4 +39,8 @@ export const PreviewPaneContainer = styled.div<{
       })
       .with("no-background", () => null)
       .exhaustive()};
+
+  iframe {
+    max-width: 100%; /* Ensure iframe respects container bounds */
+  }
 `;

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.styled.tsx
@@ -9,6 +9,7 @@ const ContentWrapper = styled.div`
   display: flex;
   align-items: stretch;
   min-height: 648px;
+  overflow: hidden; /* Prevent any content from overflowing horizontally */
 `;
 
 const SettingsAsideBlock = styled.div`
@@ -22,8 +23,8 @@ const SettingsAsideBlock = styled.div`
 `;
 
 const PreviewAreaBlock = styled.div`
+  flex: 1;
   width: 100%;
-  min-width: 50rem;
   position: relative;
   display: flex;
   flex-direction: column;
@@ -32,6 +33,7 @@ const PreviewAreaBlock = styled.div`
   gap: 1rem;
   padding: 1rem 1.5rem 2rem 1rem;
   background-color: var(--mb-color-bg-light);
+  overflow-x: auto; /* Add horizontal scrolling to the preview area only when needed */
 `;
 
 export const SettingsTabLayout = ({


### PR DESCRIPTION

This PR fixes an issue where the static embedding modal window was horizontally scrollable when configuring parameters or appearance settings. The problem was caused by fixed minimum widths in the layout components that didn't respect the container boundaries.

Changes made:
1. Removed the fixed `min-width: 50rem` from the `PreviewAreaBlock` component and replaced it with a more flexible layout that uses `flex: 1`
2. Added `overflow: hidden` to the content wrapper to prevent horizontal overflow
3. Enhanced the CodeBlock component styling to ensure code samples properly fit within their containers
4. Improved the CodeSample component to respect its parent width
5. Added appropriate overflow handling to ensure content is accessible via scrolling when needed

  Fixes #186

  [Generated by Claude Code]