### PR TITLE
[Claude Code] Fix bottom padding in dropdown menus for localization settings

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
@@ -5,6 +5,7 @@
 
   & > div {
     max-height: none !important;
+    padding-bottom: 0; /* Ensure no padding is accidentally added */
   }
 }
 
@@ -92,6 +93,7 @@
 .SelectItems_Options {
   padding: 0.75rem;
   max-height: rem(500px);
+  padding-bottom: 0.75rem; /* Explicitly set bottom padding to ensure consistency */
 }
 
 .SelectItems_Item {
@@ -153,6 +155,7 @@
   background-color: var(--mb-color-background);
   border-color: var(--mb-color-border);
   overflow: auto;
+  padding-bottom: 0.75rem; /* Add bottom padding to dropdown container */
 }
 
 .SelectError {

--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.module.css
@@ -1,5 +1,6 @@
 .dropdown {
   padding: 0;
+  padding-bottom: 0.75rem; /* Add bottom padding to ensure items at the end have proper spacing */
   overflow: auto;
   background: var(--mb-color-background);
   border-color: var(--mb-color-border);


### PR DESCRIPTION

The fix adds explicit bottom padding in several CSS files to ensure consistent spacing both at the top and bottom of dropdown menus. Specifically:

1. Added explicit bottom padding (0.75rem) to dropdown options container in Select.module.css
2. Added bottom padding to the dropdown container to ensure proper spacing for elements at the bottom of the list
3. Added bottom padding to the Popover component's dropdown class, which is used by all dropdown menus

These changes ensure a consistent and visually appealing experience when users interact with dropdown menus throughout the application, particularly in the Admin > Settings > Localization section.

  Fixes #181

  [Generated by Claude Code]