### PR TITLE
[Claude Code] Fix UI issues with excessively long dashboard and question names

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -5,6 +5,7 @@ import { t } from "ttag";
 
 /* eslint-disable-next-line no-restricted-imports -- deprecated sdk import */
 import { useInteractiveDashboardContext } from "embedding-sdk/components/public/InteractiveDashboard/context";
+import { DASHBOARD_NAME_MAX_LENGTH } from "metabase/dashboard/constants";
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
 import EditBar from "metabase/components/EditBar";
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
@@ -205,6 +206,7 @@ export function DashboardHeaderView({
                     initialValue={dashboard.name}
                     placeholder={t`Add title`}
                     isDisabled={!dashboard.can_write}
+                    maxLength={DASHBOARD_NAME_MAX_LENGTH}
                     data-testid="dashboard-name-heading"
                     onChange={handleUpdateCaption}
                   />

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -7,6 +7,9 @@ import type { EmbedDisplayParams } from "./types";
 
 export const DASHBOARD_DESCRIPTION_MAX_LENGTH = 1500;
 
+// Limit name length to prevent UI issues with menus going off-screen
+export const DASHBOARD_NAME_MAX_LENGTH = 100;
+
 export const SIDEBAR_NAME: Record<DashboardSidebarName, DashboardSidebarName> =
   {
     addQuestion: "addQuestion",

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -23,13 +23,13 @@ import * as Errors from "metabase/lib/errors";
 import type { CollectionId, Dashboard, DashboardId } from "metabase-types/api";
 
 import { DashboardCopyModalShallowCheckboxLabel } from "../components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel";
-import { DASHBOARD_DESCRIPTION_MAX_LENGTH } from "../constants";
+import { DASHBOARD_DESCRIPTION_MAX_LENGTH, DASHBOARD_NAME_MAX_LENGTH } from "../constants";
 import { isVirtualDashCard } from "../utils";
 
 const DASHBOARD_SCHEMA = Yup.object({
   name: Yup.string()
     .required(Errors.required)
-    .max(100, Errors.maxLength)
+    .max(DASHBOARD_NAME_MAX_LENGTH, Errors.maxLength)
     .default(""),
   description: Yup.string()
     .nullable()

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -20,12 +20,12 @@ import { useSelector } from "metabase/lib/redux";
 import { Button, Stack } from "metabase/ui";
 import type { CollectionId, Dashboard } from "metabase-types/api";
 
-import { DASHBOARD_DESCRIPTION_MAX_LENGTH } from "../constants";
+import { DASHBOARD_DESCRIPTION_MAX_LENGTH, DASHBOARD_NAME_MAX_LENGTH } from "../constants";
 
 const DASHBOARD_SCHEMA = Yup.object({
   name: Yup.string()
     .required(Errors.required)
-    .max(100, Errors.maxLength)
+    .max(DASHBOARD_NAME_MAX_LENGTH, Errors.maxLength)
     .default(""),
   description: Yup.string()
     .nullable()

--- a/frontend/src/metabase/questions/constants.ts
+++ b/frontend/src/metabase/questions/constants.ts
@@ -1,1 +1,2 @@
-export const QUESTION_NAME_MAX_LENGTH = 254;
+// Limit name length to prevent UI issues with menus going off-screen
+export const QUESTION_NAME_MAX_LENGTH = 100;


### PR DESCRIPTION

## Problem Description
Long dashboard or question names (254 characters or more) were causing menu options to be hidden or pushed off-screen, making them difficult or impossible to access. This issue affected the usability of the application, as users were unable to perform certain actions or view important information related to their dashboards or questions.

## Solution
The solution implements a consistent character limit for both dashboard and question names:

1. Reduced the maximum length for question names from 254 to 100 characters in `questions/constants.ts`.
2. Added a new constant `DASHBOARD_NAME_MAX_LENGTH` in `dashboard/constants.ts` with a value of 100, consistent with question names.
3. Updated the validation schema in `CreateDashboardForm` and `CopyDashboardForm` to use this constant.

  Fixes #183

  [Generated by Claude Code]