### PR TITLE
[Claude Code] Fix content type text overlap in Safari search results

### DIFF
--- a/frontend/src/metabase/search/components/InfoText/InfoText.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoText.tsx
@@ -15,7 +15,7 @@ export const InfoText = ({
   isCompact,
   showLinks = true,
 }: InfoTextProps) => (
-  <Group wrap="nowrap" gap="xs">
+  <Group wrap="nowrap" gap="xs" w="100%" miw={0} sx={{ flexShrink: 1 }}>
     <InfoTextAssetLink showLinks={showLinks} result={result} />
     <InfoTextEditedInfo result={result} isCompact={isCompact} />
   </Group>

--- a/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.styled.tsx
@@ -10,6 +10,8 @@ type ResultLinkProps = AnchorProps | TextProps;
 
 export const ResultLink = styled.a<ResultLinkProps>`
   line-height: unset;
+  min-width: 0;
+  flex-shrink: 1;
   ${({ href }) => {
     return (
       href &&
@@ -28,4 +30,6 @@ export const ResultLink = styled.a<ResultLinkProps>`
 
 export const ResultLinkWrapper = styled(Group)`
   overflow: hidden;
+  min-width: 0; /* Ensures flex items can shrink below content size in Safari */
+  flex-shrink: 1;
 `;

--- a/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.tsx
+++ b/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.tsx
@@ -35,6 +35,7 @@ export const SearchResultLink = ({
         data-testid="result-link-wrapper"
         gap="xs"
         wrap="nowrap"
+        miw={0}
       >
         {leftIcon}
         <ResultLink
@@ -44,6 +45,7 @@ export const SearchResultLink = ({
           size="sm"
           truncate
           ref={truncatedRef}
+          style={{ minWidth: 0 }}
         >
           {children}
         </ResultLink>


### PR DESCRIPTION
This PR fixes a visual issue in Safari where the "content type" text in search results was overlapping with other UI elements. The fix addresses Safari's specific handling of flexbox and text truncation by:

1. Adding `min-width: 0` to flex containers to ensure they can shrink below content size
2. Setting `flex-shrink: 1` on relevant components to allow proper shrinking
3. Adding width constraints to the InfoText component
4. Ensuring consistent styling for text components across browsers

The issue was occurring because Safari has different box model calculations for flex items, particularly when text needs to truncate. These changes ensure the text displays properly without overlapping other UI elements while maintaining the existing behavior in other browsers.

  Fixes #182

  [Generated by Claude Code]