### PR TITLE
[Claude Code] Fix Object Detail navigation state not resetting on filter changes

### DIFF
--- a/frontend/src/metabase/query_builder/actions/object-detail.ts
+++ b/frontend/src/metabase/query_builder/actions/object-detail.ts
@@ -29,6 +29,10 @@ export const ZOOM_IN_ROW = "metabase/qb/ZOOM_IN_ROW";
 export const zoomInRow =
   ({ objectId }: { objectId: ObjectId }) =>
   (dispatch: Dispatch, getState: GetState) => {
+    // First reset the zoom state to ensure we start fresh
+    dispatch(resetRowZoom());
+    
+    // Then set the new object ID for zooming
     dispatch({ type: ZOOM_IN_ROW, payload: { objectId } });
 
     // don't show object id in url if it is a row index

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -318,6 +318,8 @@ export const zoomedRowObjectId = handleActions(
     },
     [RESET_ROW_ZOOM]: { next: () => null },
     [RESET_QB]: { next: () => null },
+    // Reset zoomed row when query results change, which happens when filters are changed
+    [QUERY_COMPLETED]: { next: () => null },
   },
   null,
 );

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailWrapper.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailWrapper.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import Question from "metabase-lib/v1/Question";
 
@@ -20,6 +20,11 @@ export function ObjectDetailWrapper({
   ...rest
 }: ObjectDetailProps) {
   const [currentObjectIndex, setCurrentObjectIndex] = useState(0);
+  
+  // Reset currentObjectIndex when data changes (e.g., when filter is updated)
+  useEffect(() => {
+    setCurrentObjectIndex(0);
+  }, [data?.rows?.length]);
 
   // only show modal if this object detail was triggered via an object detail zoom action
   const shouldShowModal = isObjectDetail;


### PR DESCRIPTION
This PR fixes an issue with the Object Detail visualization where the navigation state wasn't properly resetting when filters were updated. Previously, when a user applied a filter (e.g., changing ID < 15 to ID < 10), the navigation buttons would still display record counts and positions based on the previous filter results, creating a confusing and inconsistent user experience.

The changes include:
1. Adding a useEffect hook in ObjectDetailWrapper to reset the current index when data changes
2. Modifying the zoomInRow action to ensure state is properly cleaned up before setting a new object ID
3. Updating the zoomedRowObjectId reducer to reset when new query results are received

These changes ensure that when a filter is updated in the Object Detail visualization, the navigation state is automatically reset to reflect the new filtered results, providing a consistent and intuitive user experience.

  Fixes #185

  [Generated by Claude Code]